### PR TITLE
Backward comppatible for Visit Node compiler

### DIFF
--- a/dnd-ui/webview-ui/src/compilers/cypress/VisitPageNodeCompiler.ts
+++ b/dnd-ui/webview-ui/src/compilers/cypress/VisitPageNodeCompiler.ts
@@ -9,7 +9,7 @@ export class VisitPageNodeCompiler {
 
   static compile(nodeData: any): string {
     return `
-      cy.visit('${nodeData.inPorts.url}')
+      cy.visit('${nodeData.inPorts.url || nodeData.inPorts.field}')
     `;
   }
 }


### PR DESCRIPTION
Without this it get "undefined" after you input visit node value