### PR TITLE
add compile to file directly from web

### DIFF
--- a/dnd-ui/webview-ui/src/components/SavePanel.tsx
+++ b/dnd-ui/webview-ui/src/components/SavePanel.tsx
@@ -3,21 +3,78 @@ import { memo } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Panel } from 'reactflow';
 import { faFloppyDisk } from '@fortawesome/free-regular-svg-icons';
+import { Compiler } from '../compilers';
+import { useStore } from '../context/store';
+import { useState } from 'react';
 
 function SavePanel({ onClick }) {
+  const [store] = useStore((store) => store);
+  const [currentFileHandle, setCurrentFileHandle] = useState(null);
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/File_System_API
+  async function chooseFileToSave() {
+    // Open file picker and destructure the result the first handle
+    const [fileHandle] = await window.showOpenFilePicker();
+    setCurrentFileHandle(fileHandle);
+    return fileHandle;
+  }
+
+  async function exportCompiledFile() {
+    const opts = {};
+    opts.mode = 'readwrite';
+
+    // Request permission to the file, if the user grants permission, return true.
+    const fileHandle = currentFileHandle;
+    await fileHandle.requestPermission(opts);
+    const writableStream = await currentFileHandle.createWritable();
+
+    const compiledText = Compiler.compile(store);
+
+    // write our file
+    await writableStream.write(compiledText);
+
+    // close the file and write the contents to disk.
+    await writableStream.close();
+  }
+
   // TODO: loading state when onClick running
   return (
-    <Panel
-      className="rounded !text-white font-semibold py-2 px-5 bg-green-500	cursor-pointer"
-      position="top-right"
-      style={{ right: 30 }}
-      onClick={onClick}
-    >
-      <span className="mr-1">
-        <FontAwesomeIcon icon={faFloppyDisk} />
-      </span>
-      Save
-    </Panel>
+    <div>
+      <Panel
+        className="rounded !text-white"
+        position="top-right"
+        style={{ right: 230 }}
+      >
+
+        <button
+          className="rounded !text-white font-semibold py-2 px-5 bg-green-500	cursor-pointer"
+          type="button"
+          onClick={chooseFileToSave}
+        >
+          {currentFileHandle === null ? 'Select File' : currentFileHandle.name}
+        </button>
+
+        <button
+          className="rounded !text-white font-semibold py-2 ml-2 px-5 bg-green-500	cursor-pointer"
+          type="button"
+          onClick={exportCompiledFile}
+        >
+          Export Compiled To File
+        </button>
+      </Panel>
+
+      <Panel
+        className="rounded !text-white font-semibold py-2 px-5 bg-green-500	cursor-pointer"
+        position="top-right"
+        style={{ right: 30 }}
+        onClick={onClick}
+      >
+        <span className="mr-1">
+          <FontAwesomeIcon icon={faFloppyDisk} />
+        </span>
+        Save
+      </Panel>
+    </div>
   );
 }
 


### PR DESCRIPTION
# Description
This PR to provide directly compiling on web page.

<img width="613" alt="image" src="https://github.com/TestHaters/ctflow/assets/2922275/889048a5-3ee6-452a-bbbf-e780139b84f4">

# Why
To use compiling function, we need to run the plugin on visual code. it's not convenience. When we want to test a function back and forth, it needs to run many times on many windows.

To reduce the effort for development. This web direct compiling pipeline will help us quickly test the result.

# How
I use Browser File API to access the file. First, you need to open the file you want to overwrite the compiled data. Then, hit the  Export button to overwrite it.



[![https://github.com/TestHaters/ctflow/assets/2922275/471fa474-7fae-47f2-9664-d52f4a00085b](https://github.com/TestHaters/ctflow/assets/2922275/471fa474-7fae-47f2-9664-d52f4a00085b)](https://youtu.be/J9_Igww0_ik)
